### PR TITLE
Escaped MySQL Dump statement options

### DIFF
--- a/mysite/scripts/backup_database.php
+++ b/mysite/scripts/backup_database.php
@@ -20,7 +20,7 @@ switch ($databaseConfig['type']) {
 		$h = $databaseConfig['server'];
 		$d = $databaseConfig['database'];
 
-		$cmd = "mysqldump --user=\"$u\" --password=\"$p\" --host=\"$h\" $d > ".escapeshellarg($outfile);
+		$cmd = "mysqldump --user=".escapeshellarg($u)." --password=".escapeshellarg($p)." --host=".escapeshellarg($h)." ".escapeshellarg($d)." > ".escapeshellarg($outfile);
 		exec($cmd);
 		break;
 	case 'SQLiteDatabase':


### PR DESCRIPTION
Passwords containing sensitive characters such as ampersand were causing the mysqldump command to fail on execution. I've added double quotes around the username, password and host values.
