### PR TITLE
Lock SQLite to "1.3.x-dev"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 		"silverstripe/cms": "3.1.*",
 		"silverstripe/framework": "3.1.*",
 		"silverstripe-themes/simple": "*",
-		"silverstripe/sqlite3": "dev-master"
+		"silverstripe/sqlite3": "1.3.x-dev"
 	},
 	"minimum-stability": "dev"
 }


### PR DESCRIPTION
The SQLite module is now 3.2.X compatible on master which breaks 3.1.X compatibility
