### PR TITLE
Added MS Word and Excel extensions, and phing assets/.htaccess replacement

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -163,12 +163,13 @@ Other features
 
 	<!-- Installs a freshly checked-out silverstripe project -->
 	<target name="build" depends="init">
-		<!-- if it doesn't exist, create it and the default .htaccess -->
-		<mkdir dir="assets" />
-		<echo file="assets/.htaccess" append="false">
-RemoveHandler .php .phtml .php3 .php4 .php5 .inc
-RemoveType .php .phtml .php3 .php4 .php5 .inc
-		</echo>
+		<!-- if it doesn't exist, create it and ensure the .assets-htaccess from mysite is used (same file used for deployments) -->
+		<mkdir dir="assets" />		
+		<copy tofile="${project.basedir}/assets/.htaccess" file="${project.basedir}/mysite/.assets-htaccess" overwrite="true">
+			<filterchain>
+				<expandproperties />
+			</filterchain>
+		</copy>
 
 		<echo file="mysite/BUILD_NUMBER" append="false">Build ${BUILD_STAMP}</echo>
 

--- a/mysite/.assets-htaccess
+++ b/mysite/.assets-htaccess
@@ -20,7 +20,7 @@
 # directory.
 #
 Deny from all
-<FilesMatch "\.(html|HTML|htm|HTM|xhtml|XHTML|js|JS|css|CSS|bmp|BMP|png|PNG|gif|GIF|jpg|JPG|jpeg|JPEG|ico|ICO|pcx|PCX|tif|TIF|tiff|TIFF|au|AU|mid|MID|midi|MIDI|mpa|MPA|mp3|MP3|ogg|OGG|m4a|M4A|ra|RA|wma|WMA|wav|WAV|cda|CDA|avi|AVI|mpg|MPG|mpeg|MPEG|asf|ASF|wmv|WMV|m4v|M4V|mov|MOV|mkv|MKV|mp4|MP4|swf|SWF|flv|FLV|ram|RAM|rm|RM|doc|DOC|docx|DOCX|txt|TXT|rtf|RTF|xls|XLS|xlsx|XLSX|pages|PAGES|ppt|PPT|pptx|PPTX|pps|PPS|csv|CSV|cab|CAB|arj|ARJ|tar|TAR|zip|ZIP|zipx|ZIPX|sit|SIT|sitx|SITX|gz|GZ|tgz|TGZ|bz2|BZ2|ace|ACE|arc|ARC|pkg|PKG|dmg|DMG|hqx|HQX|jar|JAR|xml|XML|pdf|PDF)$">
+<FilesMatch "\.(html|HTML|htm|HTM|xhtml|XHTML|js|JS|css|CSS|bmp|BMP|png|PNG|gif|GIF|jpg|JPG|jpeg|JPEG|ico|ICO|pcx|PCX|tif|TIF|tiff|TIFF|au|AU|mid|MID|midi|MIDI|mpa|MPA|mp3|MP3|ogg|OGG|m4a|M4A|ra|RA|wma|WMA|wav|WAV|cda|CDA|avi|AVI|mpg|MPG|mpeg|MPEG|asf|ASF|wmv|WMV|m4v|M4V|mov|MOV|mkv|MKV|mp4|MP4|swf|SWF|flv|FLV|ram|RAM|rm|RM|doc|DOC|docx|DOCX|txt|TXT|rtf|RTF|xls|XLS|xlsx|XLSX|pages|PAGES|ppt|PPT|pptx|PPTX|pps|PPS|csv|CSV|cab|CAB|arj|ARJ|tar|TAR|zip|ZIP|zipx|ZIPX|sit|SIT|sitx|SITX|gz|GZ|tgz|TGZ|bz2|BZ2|ace|ACE|arc|ARC|pkg|PKG|dmg|DMG|hqx|HQX|jar|JAR|xml|XML|pdf|PDF|xltx|XLTX|dotx|DOTX)$">
 	Allow from all
 </FilesMatch>
 


### PR DESCRIPTION
Added DOTX, dotx, XLTX, xltx extensions, and adjusted phing build to use the same assets/.htaccess file as deployments - will override if exists
