### PR TITLE
ParameterisedTestRunner registered_controller declaration - for 3.1.8

### DIFF
--- a/ssautesting/_config/dev.yml
+++ b/ssautesting/_config/dev.yml
@@ -1,0 +1,10 @@
+---
+Name: DevelopmentAdmin
+---
+DevelopmentAdmin:
+  registered_controllers:
+    tests:
+      controller: 'ParameterisedTestRunner'
+      links:
+        tests: 'See a list of unit tests to run'
+        'tests/all': 'Run all tests'


### PR DESCRIPTION
Added ParameterisedTestRunner registered_controller config declaration to work with 3.1.8
