### PR TITLE
fix(project.yml): Change to use "themes" as "theme" is deprecated, Change MySQL to use utf8mb4 (house standard) and add "simple" as selectable theme in Multisites Theme selector - Github Issue #26

### DIFF
--- a/mysite/_config/project.yml
+++ b/mysite/_config/project.yml
@@ -4,7 +4,21 @@ Name: mysite-project
 SilverStripe\Core\Manifest\ModuleManifest:
   project: mysite
 SilverStripe\View\SSViewer:
-  theme: simple
+  themes:
+    - simple
+    - '$default'
+  theme_enabled: true
+Symbiote\Multisites\Model\Site:
+  available_themes:
+    - simple
+---
+Name: mysite-db
+---
+SilverStripe\ORM\Connect\MySQLDatabase:
+  connection_charset: utf8mb4
+  connection_collation: utf8mb4_unicode_ci
+  charset: utf8mb4
+  collation: utf8mb4_unicode_ci
 ---
 Name: mysite-errors
 Only:


### PR DESCRIPTION
fix(project.yml): 

- Change to use "themes" as "theme" is deprecated
- Change MySQL to use utf8mb4 (house standard)
- Add "simple" as selectable theme in Multisites Theme selector

Github Issue #26