### PR TITLE
feat(composer.json): Update to use "prefer-stable: true" by default, like SilverStripe Recipes and also have a max composer timeout of 600 (like SilverStripe Recipes)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,10 @@
 	"require": {
 		"php": ">=5.6.0",
 		"gdmedia/ss-auto-git-ignore": "~1.0",
-		"silverstripe/cms": "~4.0",
-		"silverstripe/errorpage": "~1.0",
-		"silverstripe/framework": "~4.0",
-		"silverstripe-themes/simple": "~3.2"
+		"silverstripe/framework": "~4.0@stable",
+		"silverstripe/cms": "~4.0@stable",
+		"silverstripe/errorpage": "~1.0@stable",
+		"silverstripe-themes/simple": "~3.2@stable"
 	},
 	"require-dev": {
 		"symbiote/silverstripe-build": "~5.0",
@@ -36,5 +36,9 @@
 			"GDM\\SSAutoGitIgnore\\UpdateScript::Go"
 		]
 	},
+	"config": {
+		"process-timeout": 600
+	},
+	"prefer-stable": true,
 	"minimum-stability": "dev"
 }


### PR DESCRIPTION
feat(composer.json): 

- Update to use "prefer-stable: true" by default, like SilverStripe Recipes 
- Have a max composer timeout of 600 (like SilverStripe Recipes)