### PR TITLE
Allow large row records to be backed up

### DIFF
--- a/mysite/scripts/backup_database.php
+++ b/mysite/scripts/backup_database.php
@@ -28,7 +28,7 @@ switch ($databaseConfig['type']) {
 		$h = $databaseConfig['server'];
 		$d = $databaseConfig['database'];
 
-		$cmd = "mysqldump --user=".escapeshellarg($u)." --password=".escapeshellarg($p)." --ignore-table=$d.details --host=".escapeshellarg($h)." ".escapeshellarg($d)." | gzip > ".escapeshellarg($outfile);
+		$cmd = "mysqldump --user=".escapeshellarg($u)." --password=".escapeshellarg($p)." --ignore-table=$d.details --host=".escapeshellarg($h)." ".escapeshellarg($d)." --max_allowed_packet=512M | gzip > ".escapeshellarg($outfile);
 		exec($cmd);
 		break;
 	case 'SQLiteDatabase':
@@ -40,5 +40,3 @@ switch ($databaseConfig['type']) {
 		break;
 	default: break;
 }
-
-


### PR DESCRIPTION
This change allows records large than 16MB to be dumped during backups