### PR TITLE
update(backup_database) Ignore GTID related commands in MySQL dumps

### DIFF
--- a/mysite/scripts/backup_database.php
+++ b/mysite/scripts/backup_database.php
@@ -28,7 +28,7 @@ switch ($databaseConfig['type']) {
 		$h = $databaseConfig['server'];
 		$d = $databaseConfig['database'];
 
-		$cmd = "mysqldump --user=".escapeshellarg($u)." --password=".escapeshellarg($p)." --ignore-table=$d.details --host=".escapeshellarg($h)." ".escapeshellarg($d)." --max_allowed_packet=512M | gzip > ".escapeshellarg($outfile);
+		$cmd = "mysqldump --user=".escapeshellarg($u)." --password=".escapeshellarg($p)." --ignore-table=$d.details --host=".escapeshellarg($h)." ".escapeshellarg($d)." --max_allowed_packet=512M --set-gtid-purged=off | gzip > ".escapeshellarg($outfile);
 		exec($cmd);
 		break;
 	case 'SQLiteDatabase':

--- a/mysite/scripts/backup_database_ss4.php
+++ b/mysite/scripts/backup_database_ss4.php
@@ -52,7 +52,7 @@ switch ($envVars['SS_DATABASE_CLASS']) {
                 $h = $envVars['SS_DATABASE_SERVER'];
                 $d = $envVars['SS_DATABASE_NAME'];
 
-                $cmd = "mysqldump --user=".escapeshellarg($u)." --password=".escapeshellarg($p)." --ignore-table=$d.details --host=".escapeshellarg($h)." ".escapeshellarg($d)." --max_allowed_packet=512M | gzip > ".escapeshellarg($outfile);
+                $cmd = "mysqldump --user=".escapeshellarg($u)." --password=".escapeshellarg($p)." --ignore-table=$d.details --host=".escapeshellarg($h)." ".escapeshellarg($d)." --max_allowed_packet=512M --set-gtid-purged=off | gzip > ".escapeshellarg($outfile);
                 exec($cmd);
                 break;
         case 'SQLiteDatabase':


### PR DESCRIPTION
This setting ignores replication related settings that fail on import.