### PR TITLE
update(backups-scripts) Removed --set-gtid-purged=off for MySQL 5.6

### DIFF
--- a/mysite/scripts/backup_database.php
+++ b/mysite/scripts/backup_database.php
@@ -28,8 +28,20 @@ switch ($databaseConfig['type']) {
 		$h = $databaseConfig['server'];
 		$d = $databaseConfig['database'];
 
-		$cmd = "mysqldump --user=".escapeshellarg($u)." --password=".escapeshellarg($p)." --ignore-table=$d.details --host=".escapeshellarg($h)." ".escapeshellarg($d)." --max_allowed_packet=512M --set-gtid-purged=off | gzip > ".escapeshellarg($outfile);
-		exec($cmd);
+    $cmd = "mysql --user=".escapeshellarg($u)." --password=".escapeshellarg($p)." --host=".escapeshellarg($h)." -e \"SHOW VARIABLES LIKE 'version'\" -E";
+    preg_match("/^.*Value: ([0-9]\.[0-9]+).*/", explode("\n", shell_exec($cmd))[2], $version);
+
+    $opts = "--set-gtid-purged=off";
+    if ($version[1] == "5.6") {
+      $opts = "";
+    }
+
+    $cmd = "mysqldump --user=".escapeshellarg($u)." --password=".escapeshellarg($p)." --ignore-table=$d.details --host=".escapeshellarg($h)." ".escapeshellarg($d)." --max_allowed_packet=512M $opts | gzip > ".escapeshellarg($outfile);
+    exec($cmd, $o, $ret);
+    if ($ret != 0) {
+      echo(join("\n", $o));
+      exit(1);
+    }
 		break;
 	case 'SQLiteDatabase':
 	case 'SQLite3Database':


### PR DESCRIPTION
This change checks version of MySQL before adding the `--set-gtid-purged=off` option in the `mysqldump` command